### PR TITLE
Move <hint> out of <p>

### DIFF
--- a/source/04-PR/06.ptx
+++ b/source/04-PR/06.ptx
@@ -333,12 +333,13 @@
         <task>
           
             <p>
-              Now determine the end behavior of each piece of the numerator and each piece of the denominator. <hint>
+              Now determine the end behavior of each piece of the numerator and each piece of the denominator. 
+            </p>
+              <hint>
                 <p>
                   Use <xref ref="obs-rf-HA"></xref> to help!
                 </p>
               </hint>
-            </p>
           
         </task>
 


### PR DESCRIPTION
There was a `<hint>` nested in a `<p>` that was causing a compile error in the print version.