### PR TITLE
Instructor version

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -31,6 +31,20 @@ jobs:
                   project-root: "."
                   output-dir: "."
 
+            - name: Build instructor version with PreTeXt
+              uses: siefkenj/pretext-build-action@main
+              with:
+                  pretext-command: build instructor
+                  project-root: "."
+                  output-dir: "."
+                  
+            - name: Build instructor-print version with PreTeXt
+              uses: siefkenj/pretext-build-action@main
+              with:
+                  pretext-command: build instructor-print
+                  project-root: "."
+                  output-dir: "."
+
             - name: Build slides with PreTeXt
               uses: siefkenj/pretext-build-action@main
               with:

--- a/project.ptx
+++ b/project.ptx
@@ -12,6 +12,13 @@
       format="html" 
       deploy-dir="2024">
       <stringparams debug.project.number="the-way-it-should-be"/>
+    </target>    
+    <target 
+      name="instructor" 
+      format="html" 
+      publication="instructor.ptx"
+      deploy-dir="2024/instructor">
+      <stringparams debug.project.number="the-way-it-should-be"/>
     </target>
     <target 
       name="print" 

--- a/project.ptx
+++ b/project.ptx
@@ -26,6 +26,14 @@
       output-filename="TBIL-Precalculus-2024.pdf"
       deploy-dir="2024/pdf">
       <stringparams debug.project.number="the-way-it-should-be"/>
+    </target>    
+    <target 
+      name="instructor-print" 
+      format="pdf"
+      publication="instructor.ptx"
+      output-filename="TBIL-Precalculus-2024-Instructor-Version.pdf"
+      deploy-dir="2024/pdf">
+      <stringparams debug.project.number="the-way-it-should-be"/>
     </target>
     <target
       name="slides"

--- a/project.ptx
+++ b/project.ptx
@@ -18,7 +18,9 @@
       format="html" 
       publication="instructor.ptx"
       deploy-dir="2024/instructor">
-      <stringparams debug.project.number="the-way-it-should-be"/>
+      <stringparams 
+        commentary="yes"
+        debug.project.number="the-way-it-should-be"/>
     </target>
     <target 
       name="print" 
@@ -33,7 +35,9 @@
       publication="instructor.ptx"
       output-filename="TBIL-Precalculus-2024-Instructor-Version.pdf"
       deploy-dir="2024/pdf">
-      <stringparams debug.project.number="the-way-it-should-be"/>
+      <stringparams 
+        commentary="yes"
+        debug.project.number="the-way-it-should-be"/>
     </target>
     <target
       name="slides"

--- a/publication/instructor.ptx
+++ b/publication/instructor.ptx
@@ -35,6 +35,7 @@
     <!-- See
     https://pretextbook.org/doc/guide/html/publication-file-source.html#publication-file-source-version -->
     <!-- <version include="videos labs"/> -->
+    <version include="instructor"/>
   </source>
 
   <numbering>

--- a/publication/instructor.ptx
+++ b/publication/instructor.ptx
@@ -16,9 +16,9 @@
     <!-- There are four components (statement/hint/answer/solution) for each -->
     <!-- of five exercise types (inline/divisional/worksheet/reading/        -->
     <!-- project). Some examples:                                            -->
-    <exercise-inline statement="yes" hint="yes" answer="no" solution="no" />
+    <exercise-inline statement="yes" hint="yes" answer="yes" solution="yes" />
     <exercise-divisional statement="yes" hint="yes" />
-    <exercise-project statement="yes" hint="yes" answer="no" solution="no" />
+    <exercise-project statement="yes" hint="yes" answer="yes" solution="yes" />
     <!-- Style of fill-in-the-blanks: -->
     <fillin textstyle="underline" mathstyle="shade" />
     <!-- You can set a watermark: -->

--- a/publication/publication.ptx
+++ b/publication/publication.ptx
@@ -35,6 +35,7 @@
     <!-- See
     https://pretextbook.org/doc/guide/html/publication-file-source.html#publication-file-source-version -->
     <!-- <version include="videos labs"/> -->
+    <version include=""/> 
   </source>
 
   <numbering>

--- a/publication/publication.ptx
+++ b/publication/publication.ptx
@@ -35,7 +35,7 @@
     <!-- See
     https://pretextbook.org/doc/guide/html/publication-file-source.html#publication-file-source-version -->
     <!-- <version include="videos labs"/> -->
-    <version include=""/> 
+    <version include="main"/> 
   </source>
 
   <numbering>

--- a/source/main.ptx
+++ b/source/main.ptx
@@ -7,6 +7,7 @@
   <book xml:id="my-great-book">
     <title>Precalculus for Team-Based Inquiry Learning</title>
     <subtitle>2024 Development Edition</subtitle>
+    <subtitle component="instructor">&#x2014;Instructor Version</subtitle>
 
     <!-- Include frontmatter -->
     <xi:include href="meta/frontmatter.ptx" />

--- a/source/main.ptx
+++ b/source/main.ptx
@@ -6,8 +6,8 @@
 
   <book xml:id="my-great-book">
     <title>Precalculus for Team-Based Inquiry Learning</title>
-    <subtitle>2024 Development Edition</subtitle>
-    <subtitle component="instructor">&#x2014;Instructor Version</subtitle>
+    <subtitle component="main">2024 Development Edition</subtitle>
+    <subtitle component="instructor">2024 Development Edition &#x2014;Instructor Version</subtitle>
 
     <!-- Include frontmatter -->
     <xi:include href="meta/frontmatter.ptx" />


### PR DESCRIPTION
Beginning to implement #110.  This creates an 'instructor' html version that includes all `<answer>`s, and changes the behavior of the default `<web>` and `<print>` targets to omit them.  See the caveat [here](https://github.com/TeamBasedInquiryLearning/precalculus/issues/110#issuecomment-2057442172) that needs to be resolved before this can be merged.